### PR TITLE
feat: add cluster data protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ No modules.
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Weka cluster size | `number` | n/a | yes |
 | <a name="input_create_cloudscheduler_sa"></a> [create\_cloudscheduler\_sa](#input\_create\_cloudscheduler\_sa) | Should or not crate gcp cloudscheduler sa | `bool` | `true` | no |
 | <a name="input_get_weka_io_token"></a> [get\_weka\_io\_token](#input\_get\_weka\_io\_token) | Get get.weka.io token for downloading weka | `string` | `""` | no |
+| <a name="input_hotspare"></a> [hotspare](#input\_hotspare) | Hot-spare value. | `number` | `1` | no |
 | <a name="input_install_url"></a> [install\_url](#input\_install\_url) | Path to weka installation tar object | `string` | `""` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Weka cluster backends machines type | `string` | `"c2-standard-8"` | no |
 | <a name="input_machine_types_nics_number_map"></a> [machine\_types\_nics\_number\_map](#input\_machine\_types\_nics\_number\_map) | Map of machine type to supported nics number | `map(number)` | <pre>{<br>  "c2-standard-16": 7,<br>  "c2-standard-8": 4<br>}</pre> | no |
@@ -140,8 +141,10 @@ No modules.
 | <a name="input_private_dns_zone"></a> [private\_dns\_zone](#input\_private\_dns\_zone) | Name of private dns zone | `string` | n/a | yes |
 | <a name="input_private_network"></a> [private\_network](#input\_private\_network) | Deploy weka in private network | `bool` | `false` | no |
 | <a name="input_project"></a> [project](#input\_project) | Project id | `string` | n/a | yes |
+| <a name="input_protection_level"></a> [protection\_level](#input\_protection\_level) | Cluster data protection level. | `number` | `2` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region name | `string` | n/a | yes |
 | <a name="input_sa_email"></a> [sa\_email](#input\_sa\_email) | Service account email | `string` | n/a | yes |
+| <a name="input_stripe_width"></a> [stripe\_width](#input\_stripe\_width) | Stripe width = cluster\_size - protection\_level - 1 (by default). | `number` | `-1` | no |
 | <a name="input_subnets_name"></a> [subnets\_name](#input\_subnets\_name) | Subnets list name | `list(string)` | n/a | yes |
 | <a name="input_vpc_connector"></a> [vpc\_connector](#input\_vpc\_connector) | Connector name to use for serverless vpc access | `string` | n/a | yes |
 | <a name="input_vpcs"></a> [vpcs](#input\_vpcs) | List of vpcs name | `list(string)` | n/a | yes |

--- a/cloud-functions/cloud_functions_test.go
+++ b/cloud-functions/cloud_functions_test.go
@@ -3,6 +3,10 @@ package cloud_functions
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/common"
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/functions/clusterize"
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/functions/clusterize_finalization"
@@ -13,9 +17,6 @@ import (
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/functions/scale_up"
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/functions/status"
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/functions/terminate"
-	"os"
-	"testing"
-	"time"
 )
 
 func Test_bunch(t *testing.T) {
@@ -46,7 +47,16 @@ func Test_clusterize(t *testing.T) {
 	bucket := "weka-poc-wekaio-rnd-state"
 	instanceName := "weka-poc-vm-test"
 
-	fmt.Printf("res:%s", clusterize.Clusterize(project, zone, hostsNum, nicsNum, gws, clusterName, nvmesNumber, usernameId, passwordId, bucket, instanceName, clusterizeFinalizationUrl))
+	dataProtectionParams := clusterize.DataProtectionParams{
+		StripeWidth:     2,
+		ProtectionLevel: 2,
+		Hotspare:        1,
+	}
+
+	fmt.Printf("res:%s", clusterize.Clusterize(
+		project, zone, hostsNum, nicsNum, gws, clusterName, nvmesNumber, usernameId, passwordId, bucket, instanceName,
+		clusterizeFinalizationUrl, dataProtectionParams,
+	))
 }
 
 func Test_fetch(t *testing.T) {

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -6,6 +6,11 @@ locals {
   sa_email = var.sa_email
 }
 
+locals {
+  stripe_width_calculated = var.cluster_size - var.protection_level - 1
+  stripe_width = local.stripe_width_calculated < 16 ? local.stripe_width_calculated : 16
+}
+
 data "archive_file" "function_zip" {
   type        = "zip"
   output_path = local.function_zip_path
@@ -274,6 +279,9 @@ resource "google_cloudfunctions2_function" "clusterize_function" {
       PASSWORD_ID: google_secret_manager_secret_version.password_secret_key.id
       BUCKET: google_storage_bucket.weka_deployment.name
       CLUSTERIZE_FINALIZATION_URL: google_cloudfunctions2_function.clusterize_finalization_function.service_config[0].uri
+      PROTECTION_LEVEL : var.protection_level
+      STRIPE_WIDTH : var.stripe_width != -1 ? var.stripe_width : local.stripe_width
+      HOTSPARE : var.hotspare
     }
   }
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,11 @@ variable "weka_username" {
 variable "cluster_size" {
   type        = number
   description = "Weka cluster size"
+
+  validation {
+    condition = var.cluster_size >= 6
+    error_message = "Cluster size should be at least 6."
+  }
 }
 
 variable "subnets_name" {
@@ -175,4 +180,30 @@ variable "machine_types_nics_number_map" {
     c2-standard-8 = 4
     c2-standard-16 = 7
   }
+}
+
+variable "protection_level" {
+  type = number
+  default = 2
+  description = "Cluster data protection level."
+  validation {
+    condition     = var.protection_level == 2 || var.protection_level == 4
+    error_message = "Allowed protection_level values: [2, 4]."
+  }
+}
+
+variable "stripe_width" {
+  type = number
+  default = -1
+  description = "Stripe width = cluster_size - protection_level - 1 (by default)."
+  validation {
+    condition     = var.stripe_width == -1 || var.stripe_width >= 3 && var.stripe_width <= 16
+    error_message = "The stripe_width value can take values from 3 to 16."
+  }
+}
+
+variable "hotspare" {
+  type = number
+  default = 1
+  description = "Hot-spare value."
 }


### PR DESCRIPTION
Deployment passed successfully:
```
~/weka/terraform-gcp-weka/examples/public_vpc add-cluster-data-protection !1 ❯ curl -m 70 -X POST https://ks-kristina-status-v5lrsk3bvq-ew.a.run.app \                   14:39:05
-H "Authorization:bearer $(gcloud auth print-identity-token)" \
-H "Content-Type:application/json"

{"initial_size":6,"desired_size":6,"clusterized":true,"ready_for_clusterization":[],"system_status":{"io_status":"STARTED","upgrade":"","activity":{"num_ops":0,"num_reads":0,"num_writes":0,"obs_download_bytes_per_second":0,"obs_upload_bytes_per_second":0,"sum_bytes_read":0,"sum_bytes_written":0},"hosts":{"active_count":6,"backends":{"active":6,"total":6},"clients":{"active":0,"total":0},"totalCount":0}},"raw_weka_status":{"overlay":{"format":3,"client_nodes_at_risk":0,"client_nodes_not_supported":0,"client_nodes_safety_histogram":[0,0,0,0],"clients_branching_factor":200,"backend_nodes_safety_histogram":[0,0,0,23],"branching_factor":40},"activity":{"obs_upload_bytes_per_second":0,"sum_bytes_read":0,"num_writes":0,"obs_download_bytes_per_second":0,"sum_bytes_written":0,"num_reads":0,"num_ops":0},"hot_spare":1,"io_status":"STARTED","last_init_failure":"","drives":{"active":6,"total":6},"name":"kristina","upgrade":"","io_status_changed_time":"2023-04-28T11:42:22.00802Z","short_drive_grace_on_failure_secs":10,"io_nodes":{"active":18,"total":18},"cloud":{"enabled":false,"healthy":true,"proxy":"","url":"https:\/\/api.home.weka.io"},"release_hash":"19b3e8a71ba4426ef6d9885810ffae25ab02a71e","rebuild":{"movingData":false,"requiredFDsForRebuild":3,"movingQuorums":false,"unavailablePercent":0,"enoughActiveFDs":true,"totalCopiesMiB":0,"unavailableMiB":0,"progressPercent":0,"stripeDisks":5,"isInited":true,"numActiveFDs":6,"totalCopiesDoneMiB":0,"protectionState":[{"percent":100,"numFailures":0,"MiB":243072},{"percent":0,"numFailures":1,"MiB":0},{"percent":0,"numFailures":2,"MiB":0}]},"init_stage":"INITIALIZED","failure_domains_enabled":false,"long_drive_grace_on_failure_secs":360,"hosts":{"total_count":6,"backends":{"active":6,"total":6},"active_count":6,"clients":{"active":0,"total":0}},"last_init_failure_code":"","wide_range_nodes_allocation":true,"stripe_data_drives":3,"release":"4.1.0.77","buckets_info":{"criticalRaidFillLevelPPM":970000,"ssdsFillLevelPPM":176716,"capacityDiscrepancyGracePPM":50000,"thinProvisionState":{"usableWritable":317974118,"totalSSDBudgets":0,"shrinkageFactor":{"val":4096}},"averageFillLevelPPM":8608,"shrunkAtGeneration":"ConfigGeneration\u003cINVALID\u003e","hysteresisPPM":20000,"maxProvisionablePPM":920000,"placementAllocationThresholdPPM":450000,"reportedRaidFillLevelSeverity":"Normal","maxPrefetchRPCs":256},"active_alerts_count":20,"time":{"cluster_time":"2023-04-28T11:44:01.985275Z","cluster_local_utc_offset":"+00:00","allowed_clock_skew_secs":60,"cluster_local_utc_offset_seconds":0},"net":{"link_layer":"ETH"},"buckets":{"active":102,"global_flush_generation":1,"global_flush_status":"NONE","total":102,"shutdown_finished":0,"flush_finished":0},"scrubber_bytes_per_sec":134217728,"init_stage_changed_time":"2023-04-28T11:42:10.497962Z","capacity":{"total_bytes":1085351657472,"hot_spare_bytes":217070329856,"unprovisioned_bytes":1085351657472},"is_cluster":true,"block_upgrade_task":{"type":"INVALID","progress":0,"taskId":"BlockTaskId\u003c0\u003e","state":"IDLE"},"grim_reaper":{"enabled":true,"is_cluster_fully_connected":true,"node_with_least_links":null},"status":"OK","stripe_protection_drives":2,"guid":"9f666f30-6a61-4038-990b-4778c0a31a52","start_io_starting_drives_grace_secs":30,"start_io_starting_io_nodes_grace_secs":30,"hanging_ios":{"event_driver_frontend_threshold_secs":1800,"last_emitted_backend_no_longer_detected_event":"","alerts_threshold_secs":900,"last_emitted_backend_event":"","event_backend_threshold_secs":1800,"last_emitted_driver_frontend_no_longer_detected_event":"","last_emitted_driver_frontend_event":"","event_nfs_frontend_threshold_secs":1800,"last_emitted_nfs_frontend_event":"","last_emitted_nfs_frontend_no_longer_detected_event":""},"last_init_failure_time":"","nodes":{"blacklisted":0,"total":24},"licensing":{"io_start_eligibility":true,"usage":{"drive_capacity_gb":2415,"usable_capacity_gb":1085,"obs_capacity_gb":0},"mode":"Unlicensed"}}}
```