### PR TITLE
fix: permissions err on scale_down, improve func errs

### DIFF
--- a/cloud-functions/functions/fetch/fetch.go
+++ b/cloud-functions/functions/fetch/fetch.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions/common"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 type HgInstance struct {

--- a/modules/service_account/main.tf
+++ b/modules/service_account/main.tf
@@ -19,6 +19,7 @@ resource "google_project_iam_member" "sa_member_role" {
   for_each = toset([
     "roles/secretmanager.secretAccessor",
     "roles/compute.serviceAgent",
+    "roles/compute.loadBalancerServiceUser", # needed for GetHealthRegionBackendServiceRequest
     "roles/cloudfunctions.developer",
     "roles/workflows.invoker",
     "roles/vpcaccess.serviceAgent",


### PR DESCRIPTION
Fixes: https://wekaio.atlassian.net/browse/GCP-333

- add missing permission
- return BadRequest on cloud functions failures (instead of 200 OK)

Scale down workflow responses:
- after instance termination (scaled down 8 -> 7)
```
{
  "body": "terminated instances (1): [kristina-20231116202801000]",
  "code": 200,
  "headers": {...}
}
```
- normally
```
{
  "body": "terminated instances (0): []",
  "code": 200,
  "headers": {...}
}
```