### PR TITLE
fix: avoid client replacement on second tf apply

### DIFF
--- a/modules/clients/main.tf
+++ b/modules/clients/main.tf
@@ -81,7 +81,7 @@ resource "google_compute_instance" "this" {
     on_host_maintenance = try(var.instance_config_overrides[var.machine_type].host_maintenance, "MIGRATE")
   }
   lifecycle {
-    ignore_changes = [network_interface]
+    ignore_changes = [network_interface, metadata_startup_script]
   }
   depends_on = [google_compute_disk.this]
 }


### PR DESCRIPTION
reason for clients being replaced:
```  # module.weka_deployment.module.clients[0].google_compute_instance.this[0] must be replaced
-/+ resource "google_compute_instance" "this" {
      ~ cpu_platform            = "Intel Cascade Lake" -> (known after apply)
      ~ current_status          = "RUNNING" -> (known after apply)
      - enable_display          = false -> null
      ~ guest_accelerator       = [] -> (known after apply)
      ~ id                      = "projects/wekaio-rnd/zones/europe-west1-b/instances/ks-kristina-client-0" -> (known after apply)
      ~ instance_id             = "4200633238759600876" -> (known after apply)
      ~ label_fingerprint       = "42WmSpB8rSM=" -> (known after apply)
      - labels                  = {} -> null
      ~ metadata_fingerprint    = "Mu5_su6SxQo=" -> (known after apply)
      ~ metadata_startup_script = <<-EOT # forces replacement
...
```