### PR TITLE
feat: upgrade go runtime to 1.22

### DIFF
--- a/cloud-functions/cloud_functions_test.go
+++ b/cloud-functions/cloud_functions_test.go
@@ -190,7 +190,7 @@ func Test_scaleUp(t *testing.T) {
 	backendTemplate := "projects/wekaio-rnd/global/instanceTemplates/weka-poc-backends"
 	functionRootUrl := "https://europe-west1-wekaio-rnd.cloudfunctions.net"
 	yumRepoServer := ""
-	proxyUrl = ""
+	proxyUrl := ""
 	ctx := context.TODO()
 	scale_up.CreateInstance(ctx, project, zone, backendTemplate, instanceName, yumRepoServer, proxyUrl, functionRootUrl)
 	instances := common.GetInstancesByClusterLabel(ctx, project, zone, clusterName)

--- a/cloud-functions/go.mod
+++ b/cloud-functions/go.mod
@@ -1,6 +1,6 @@
 module github.com/weka/gcp-tf/modules/deploy_weka/cloud-functions
 
-go 1.20
+go 1.22
 
 require (
 	cloud.google.com/go/compute v1.19.1

--- a/cloud-functions/go.sum
+++ b/cloud-functions/go.sum
@@ -9,6 +9,7 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/iam v0.13.0 h1:+CmB+K0J/33d0zSQ9SlFWUeCCEn5XJA0ZMZ3pHE9u8k=
 cloud.google.com/go/iam v0.13.0/go.mod h1:ljOg+rcNfzZ5d6f1nAUJ8ZIxOaZUVoS14bKCtaLZ/D0=
 cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
+cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 cloud.google.com/go/secretmanager v1.10.0 h1:pu03bha7ukxF8otyPKTFdDz+rr9sE3YauS5PliDXK60=
 cloud.google.com/go/secretmanager v1.10.0/go.mod h1:MfnrdvKMPNra9aZtQFvBcvRU54hbPD8/HayQdlUgJpU=
 cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
@@ -65,6 +66,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/s2a-go v0.1.3 h1:FAgZmpLl/SXurPEZyCMPBIiiYeTbqfjlbdnCNTAkbGE=
 github.com/google/s2a-go v0.1.3/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -141,6 +143,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -36,7 +36,7 @@ resource "google_cloudfunctions2_function" "cloud_internal_function" {
   description = "deploy, fetch, resize, clusterize, clusterize finalization, join, join_finalization, terminate, transient, terminate_cluster, scale_up functions"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
   build_config {
-    runtime     = "go120"
+    runtime     = "go122"
     entry_point = "CloudInternal"
     worker_pool = local.worker_pool_id
     source {
@@ -119,7 +119,7 @@ resource "google_cloudfunctions2_function" "scale_down_function" {
   description = "scale cluster down"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
   build_config {
-    runtime     = "go120"
+    runtime     = "go122"
     entry_point = "ScaleDown"
     worker_pool = local.worker_pool_id
     source {
@@ -158,7 +158,7 @@ resource "google_cloudfunctions2_function" "status_function" {
   description = "get cluster status"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
   build_config {
-    runtime     = "go120"
+    runtime     = "go122"
     entry_point = "Status"
     worker_pool = local.worker_pool_id
     source {


### PR DESCRIPTION
Go 1.20 runtime deprecation date: 2024-05-01
GCP docs: https://cloud.google.com/functions/docs/runtime-support#go