### PR TITLE
fix: udp mount for client with multiple NICs

### DIFF
--- a/modules/clients/init.sh
+++ b/modules/clients/init.sh
@@ -22,3 +22,47 @@ if [[ "$os" = *"Rocky"* ]]; then
 fi
 
 apt update && apt install -y net-tools && apt install -y gcc-12 || true
+
+all_subnets=(${subnets})
+echo "subnets: $${all_subnets[@]}"
+
+cat >>/usr/sbin/remove-routes.sh <<EOF
+#!/bin/bash
+set -ex
+EOF
+for(( i=1; i<${nics_num}; i++ )); do
+  subnet=$${all_subnets[$i]}
+  cat >>/usr/sbin/remove-routes.sh <<EOF
+while ! ip route | grep eth$i; do
+  ip route
+  sleep 5
+done
+while ip route | grep "$subnet" | grep "eth$i"; do
+  echo "Removing route for $subnet on eth$i"
+  ip route del $subnet dev eth$i
+done
+EOF
+done
+
+chmod +x /usr/sbin/remove-routes.sh
+
+cat >/etc/systemd/system/remove-routes.service <<EOF
+[Unit]
+Description=Remove specific routes
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/sbin/remove-routes.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ip route # show routes before removing
+systemctl daemon-reload
+systemctl enable remove-routes.service
+systemctl start remove-routes.service
+systemctl status remove-routes.service || true # show status of remove-routes.service
+ip route # show routes after removing

--- a/modules/clients/main.tf
+++ b/modules/clients/main.tf
@@ -8,10 +8,14 @@ data "google_compute_subnetwork" "this" {
 locals {
   network_project_id      = var.network_project_id != "" ? var.network_project_id : var.project_id
   private_nic_first_index = var.assign_public_ip ? 1 : 0
+  nics_num                = var.clients_use_dpdk ? var.frontend_container_cores_num + 1 : 1
+
   preparation_script = templatefile("${path.module}/init.sh", {
     yum_repo_server = var.yum_repo_server
+    nics_num        = local.nics_num
+    subnets         = join(" ", data.google_compute_subnetwork.this.*.ip_cidr_range)
   })
-  nics_num = var.clients_use_dpdk ? var.frontend_container_cores_num + 1 : 1
+
   mount_wekafs_script = templatefile("${path.module}/mount_wekafs.sh", {
     all_subnets                  = split("\n", replace(join("\n", data.google_compute_subnetwork.this.*.ip_cidr_range), "/\\S+//", ""))[0]
     all_gateways                 = join(" ", data.google_compute_subnetwork.this.*.gateway_address)


### PR DESCRIPTION
Jira ticket: https://wekaio.atlassian.net/browse/CLOUD-1948

e.g. for a client with 2 NICs, initial routes:
```
+ ip route
default via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.12 metric 100
10.0.0.0/24 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.12 metric 100
10.0.0.1 dev eth0 proto dhcp scope link src 10.0.0.12 metric 100
10.1.0.0/24 via 10.1.0.1 dev eth1 proto static
10.1.0.0/24 via 10.1.0.1 dev eth1 proto dhcp src 10.1.0.10 metric 101
10.1.0.1 dev eth1 scope link
10.1.0.1 dev eth1 proto dhcp scope link src 10.1.0.10 metric 101
```
after removal:
```
[kristina.solovyova@ks-kristina-client-0 ~]$ ip route
default via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.12 metric 100
10.0.0.0/24 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.12 metric 100
10.0.0.1 dev eth0 proto dhcp scope link src 10.0.0.12 metric 100
10.1.0.1 dev eth1 scope link
10.1.0.1 dev eth1 proto dhcp scope link src 10.1.0.10 metric 101
```
mount in UPD mode:
```
[kristina.solovyova@ks-kristina-client-0 ~]$ sudo mount -t wekafs -o net=udp 10.0.0.3/default /mnt/weka
wekafs_mount_helper: Mounting 10.0.0.3/default on /mnt/weka
Basing mount on container client
Creating Weka container 'client' in version 4.2.11
Preparing version 4.2.11 of container client
Base port was not explicitly provided, the container will use 14000
Applying resources
Starting container 'client'
Waiting for container 'client' to join cluster
Container "client" is ready (pid = 95721)
wekafs_mount_helper: Executing `mount --no-canonicalize -i -t wekafs -o inode_bits=auto,dentry_max_age_positive=1000,dentry_max_age_negative=0,readahead_kb=32768,container_name=client,writecache,relatime,rw,relatime_threshold=0,token=XXX 10.0.0.3/default /mnt/weka`
Mount completed successfully
```