### PR TITLE
Set allow_global_access=true for forwarding rules.

### DIFF
--- a/health_check.tf
+++ b/health_check.tf
@@ -33,6 +33,7 @@ resource "google_compute_forwarding_rule" "google_compute_forwarding_rule" {
   region                = var.region
   load_balancing_scheme = "INTERNAL"
   all_ports             = true
+  allow_global_access   = true
   network               = data.google_compute_network.this[0].self_link
   subnetwork            = data.google_compute_subnetwork.this[0].self_link
   lifecycle {
@@ -89,6 +90,7 @@ resource "google_compute_forwarding_rule" "ui_forwarding_rule" {
   region                = var.region
   load_balancing_scheme = "INTERNAL"
   all_ports             = true
+  allow_global_access   = true
   network               = data.google_compute_network.this[0].self_link
   subnetwork            = data.google_compute_subnetwork.this[0].self_link
   lifecycle {


### PR DESCRIPTION
This setting allows the forwarding rules to be accessed from regions outside the region weka is installed in.

For example if I try an access http://ui-weka-us-central1.example.com:14000/ from a machine inside us-central1 region that will work fine, but if I try and access it from my local network it will not work as the load balancer doesn't allow global access.