### PR TITLE
Push google versions to 5.11.x

### DIFF
--- a/modules/clients/versions.tf
+++ b/modules/clients/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/clients/versions.tf
+++ b/modules/clients/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.83.0"
+      version = "~> 4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/protocol_gateways/versions.tf
+++ b/modules/protocol_gateways/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/protocol_gateways/versions.tf
+++ b/modules/protocol_gateways/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/service_account/versions.tf
+++ b/modules/service_account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/service_account/versions.tf
+++ b/modules/service_account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/shared_vpcs/versions.tf
+++ b/modules/shared_vpcs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/shared_vpcs/versions.tf
+++ b/modules/shared_vpcs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/vpc_peering/versions.tf
+++ b/modules/vpc_peering/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/vpc_peering/versions.tf
+++ b/modules/vpc_peering/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/modules/worker_pool/versions.tf
+++ b/modules/worker_pool/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/modules/worker_pool/versions.tf
+++ b/modules/worker_pool/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.83.0"
+      version = "~> 4.84.0"
     }
   }
   required_version = ">=1.3.1"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.38.0"
+      version = "~>4.84.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.84.0"
+      version = "~>5.11.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
I am working on a thin terraform module that uses terraform-gcp-weka so that WEKA can more easily be deployed with [Google Cloud's Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit) (formerly HPC Toolkit). The Cluster Toolkit puts specific requirements on the google and google-beta provider versions for terraform; 4.38.x falls outside of the supported versions unfortunately.

This patch updates the google provider to 5.11.x and google-beta providers to 4.84.x which makes this repository compatible with the Cluster Toolkit and specifically SchedMD's community contributed modules for Slurm-GCP.
