### PR TITLE
feat: migrate exiting NFS instances to state on module upgrade

### DIFF
--- a/cloud-functions/functions/clusterize/clusterize.go
+++ b/cloud-functions/functions/clusterize/clusterize.go
@@ -109,6 +109,12 @@ func NFSClusterize(ctx context.Context, p ClusterizationParams) (clusterizeScrip
 		return
 	}
 
+	err = common.SetDeletionProtection(ctx, p.Project, p.Zone, p.Bucket, p.NFSStateObject, p.Vm.Name)
+	if err != nil {
+		clusterizeScript = cloudCommon.GetErrorScript(err, reportFunction, p.Vm.Protocol)
+		return
+	}
+
 	msg := fmt.Sprintf("This (%s) is nfs instance %d/%d that is ready for joining the interface group", p.Vm.Name, len(state.Instances), nfsProtocolgwsNum)
 	log.Info().Msgf(msg)
 	if len(state.Instances) != nfsProtocolgwsNum {

--- a/cloud-functions/functions/clusterize/clusterize.go
+++ b/cloud-functions/functions/clusterize/clusterize.go
@@ -147,6 +147,11 @@ func NFSClusterize(ctx context.Context, p ClusterizationParams) (clusterizeScrip
 		Name:           p.Vm.Name,
 	}
 
+	err = common.UpdateStateNfsMigrated(ctx, p.Bucket, p.NFSStateObject)
+	if err != nil {
+		clusterizeScript = cloudCommon.GetErrorScript(err, reportFunction, p.Vm.Protocol)
+		return
+	}
 	clusterizeScript = scriptGenerator.GetNFSSetupScript()
 	log.Info().Msg("Clusterization script for NFS generated")
 	return

--- a/cloud-functions/functions/gcp_functions_def/functions_def.go
+++ b/cloud-functions/functions/gcp_functions_def/functions_def.go
@@ -21,6 +21,7 @@ func NewFuncDef(rootUrl string) functions_def.FunctionDef {
 		functions_def.Report:                 true,
 		functions_def.Join:                   true,
 		functions_def.JoinFinalization:       true,
+		functions_def.JoinNfsFinalization:    true,
 		functions_def.Fetch:                  true,
 		functions_def.Status:                 true,
 	}

--- a/cloud-functions/functions/scale_up/scale_up.go
+++ b/cloud-functions/functions/scale_up/scale_up.go
@@ -268,7 +268,7 @@ func MigrateExistingNFSInstances(
 		log.Info().Msgf("Migrated %d existing NFS instances to state: %v", len(gwVms), migratedInstanceNames)
 	}
 
-	nfsState.MigrateExisting = false
+	nfsState.NfsInstancesMigrated = true
 	err = common.RetryWriteState(stateHandler, ctx, nfsState)
 	return
 }

--- a/cloud-functions/go.mod
+++ b/cloud-functions/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.5
 	github.com/lithammer/dedent v1.1.0
 	github.com/rs/zerolog v1.29.1
-	github.com/weka/go-cloud-lib v0.0.0-20240718085251-5f5e85497144
+	github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a
 	google.golang.org/api v0.186.0
 	google.golang.org/protobuf v1.34.2
 )

--- a/cloud-functions/go.mod
+++ b/cloud-functions/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.5
 	github.com/lithammer/dedent v1.1.0
 	github.com/rs/zerolog v1.29.1
-	github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a
+	github.com/weka/go-cloud-lib v0.0.0-20240825112755-12092b948f7f
 	google.golang.org/api v0.186.0
 	google.golang.org/protobuf v1.34.2
 )

--- a/cloud-functions/go.sum
+++ b/cloud-functions/go.sum
@@ -96,8 +96,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a h1:6Uh+ZT33keG4vEMRsF3r+E6cAp2aER1tldzfLVHOJac=
-github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
+github.com/weka/go-cloud-lib v0.0.0-20240825112755-12092b948f7f h1:ci/JIXwVRqxtmT2yJbSyY9K9KacnpjsNHWYra2o5SCQ=
+github.com/weka/go-cloud-lib v0.0.0-20240825112755-12092b948f7f/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=

--- a/cloud-functions/go.sum
+++ b/cloud-functions/go.sum
@@ -96,10 +96,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/weka/go-cloud-lib v0.0.0-20240717102736-de42f2cd2e04 h1:2AF5Z17vKtrZpRI+FtlzUE0gYW7qkt9nxe6+7bwb9ks=
-github.com/weka/go-cloud-lib v0.0.0-20240717102736-de42f2cd2e04/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
-github.com/weka/go-cloud-lib v0.0.0-20240718085251-5f5e85497144 h1:AMFRqKpeQZVbveJb2iuDUVM9e5u1tapQi6WxZcBnPAY=
-github.com/weka/go-cloud-lib v0.0.0-20240718085251-5f5e85497144/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
+github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a h1:6Uh+ZT33keG4vEMRsF3r+E6cAp2aER1tldzfLVHOJac=
+github.com/weka/go-cloud-lib v0.0.0-20240823131416-0925cce4f83a/go.mod h1:FCQuk2bLvtDHe2Kjsu0oInJP1VOVsuxqPGHGMmVIPMg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=

--- a/cloud-functions/main.go
+++ b/cloud-functions/main.go
@@ -97,6 +97,8 @@ func CloudInternal(w http.ResponseWriter, r *http.Request) {
 		Fetch(w, r)
 	case "join_finalization":
 		JoinFinalization(w, r)
+	case "join_nfs_finalization":
+		JoinFinalization(w, r)
 	case "report":
 		Report(w, r)
 	case "resize":

--- a/cloud-functions/main.go
+++ b/cloud-functions/main.go
@@ -444,7 +444,7 @@ func ScaleUp(w http.ResponseWriter, r *http.Request) {
 
 	var nfsGatewaysNumber int
 	var nfsDesiredSize int
-	var nfsMigrateExisting bool
+	var nfsInstancesMigrated bool
 
 	if nfsStateObject != "" {
 		nfsGateways, err := common.GetInstancesByProtocolGwLabel(ctx, project, zone, nfsGatewaysName)
@@ -466,10 +466,10 @@ func ScaleUp(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Info().Msgf("NFS desired size is: %d", nfsState.DesiredSize)
 		nfsDesiredSize = nfsState.DesiredSize
-		nfsMigrateExisting = nfsState.MigrateExisting
+		nfsInstancesMigrated = nfsState.NfsInstancesMigrated
 	}
 
-	if nfsMigrateExisting && state.Clusterized {
+	if nfsStateObject != "" && !nfsInstancesMigrated && state.Clusterized {
 		migratedInstances, err := scale_up.MigrateExistingNFSInstances(
 			ctx, project, zone, bucket, nfsStateObject, nfsGatewaysName, nfsInterfaceGroupName, nfsInstanceGroup, instanceGroup, usernameId, deploymentPasswordId, adminPasswordId,
 		)

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -41,7 +41,7 @@ resource "google_storage_bucket_object" "cloud_functions_zip" {
 # ======================== deploy ============================
 resource "google_cloudfunctions2_function" "cloud_internal_function" {
   name        = local.cloud_internal_function_name
-  description = "deploy, fetch, resize, clusterize, clusterize finalization, join, join_finalization, terminate, transient, terminate_cluster, scale_up functions"
+  description = "deploy, fetch, resize, clusterize, clusterize finalization, join, join_finalization, join_nfs_finalization, terminate, transient, terminate_cluster, scale_up functions"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
   build_config {
     runtime     = "go122"

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -78,7 +78,7 @@ resource "google_cloudfunctions2_function" "cloud_internal_function" {
       DEPLOYMENT_PASSWORD_ID : google_secret_manager_secret.weka_deployment_password.id
       TOKEN_ID : var.get_weka_io_token == "" ? "" : google_secret_manager_secret.secret_token[0].id
       BUCKET : local.state_bucket
-      STATE_OBJ_NAME : google_storage_bucket_object.state.name
+      STATE_OBJ_NAME : local.state_object_name
       INSTALL_URL : local.install_weka_url
       # Configuration for google_cloudfunctions2_function.cloud_internal_function may not refer to itself.
       # REPORT_URL : format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
@@ -117,7 +117,7 @@ resource "google_cloudfunctions2_function" "cloud_internal_function" {
       TRACES_PER_FRONTEND : var.traces_per_ionode
       # NFS vars
       NFS_GATEWAYS_NAME : var.nfs_setup_protocol ? local.gateways_name : ""
-      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? google_storage_bucket_object.nfs_state[0].name : ""
+      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? local.nfs_state_object_name : ""
       NFS_GATEWAYS_TEMPLATE_NAME : var.nfs_setup_protocol ? local.gateways_name : ""
       NFS_INTERFACE_GROUP_NAME : var.nfs_interface_group_name
       NFS_SECONDARY_IPS_NUM : var.nfs_protocol_gateway_secondary_ips_per_nic
@@ -212,8 +212,8 @@ resource "google_cloudfunctions2_function" "status_function" {
       PROJECT : var.project_id
       ZONE : var.zone
       BUCKET : local.state_bucket
-      STATE_OBJ_NAME : google_storage_bucket_object.state.name
-      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? google_storage_bucket_object.nfs_state[0].name : ""
+      STATE_OBJ_NAME : local.state_object_name
+      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? local.nfs_state_object_name : ""
       INSTANCE_GROUP : google_compute_instance_group.this.name
       NFS_INSTANCE_GROUP : var.nfs_setup_protocol ? google_compute_instance_group.nfs[0].name : ""
       USER_NAME_ID : google_secret_manager_secret.secret_weka_username.id

--- a/state_object.tf
+++ b/state_object.tf
@@ -21,12 +21,12 @@ resource "google_storage_bucket_object" "nfs_state" {
   bucket       = local.state_bucket
   content_type = "application/json"
   content = jsonencode({
-    initial_size          = var.nfs_protocol_gateways_number
-    desired_size          = var.nfs_protocol_gateways_number
-    instances             = []
-    clusterized           = false
-    clusterization_target = var.nfs_protocol_gateways_number
-    migrate_existing      = true
+    initial_size           = var.nfs_protocol_gateways_number
+    desired_size           = var.nfs_protocol_gateways_number
+    instances              = []
+    clusterized            = false
+    clusterization_target  = var.nfs_protocol_gateways_number
+    nfs_instances_migrated = false
   })
 
   lifecycle {


### PR DESCRIPTION
Depends on https://github.com/weka/go-cloud-lib/pull/99

Tested "upgrade" from cluster created on `main` to this branch:
- created cluster with 2 NFS VMs — these instances have no labels, no deletion protection and no instance group
```
weka nfs interface-group --json
[
    {
        "allow_manage_gids": true,
        "gateway": "255.255.255.255",
        "ips": [],
        "name": "weka-ig",
        "ports": [
            {
                "host_id": "HostId<18>",
                "host_uid": "a1dacd46-6a57-319a-d776-d3960b823cba",
                "port": "eth0",
                "status": "OK"
            },
            {
                "host_id": "HostId<19>",
                "host_uid": "eab6f13e-4a51-6d78-50a8-5ea3371bfaea",
                "port": "eth0",
                "status": "OK"
            }
        ],
        "status": "OK",
        "subnet_mask": "255.255.255.255",
        "type": "NFS",
        "uid": "3eb82e60-5e80-edfb-5479-73d4602ea880"
    }
]
```
- tf destroy summary before removing nfs VMs from tf state: 
```
# module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_template.this must be replaced
# module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_from_template.this[1] will be destroyed
# module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_from_template.this[0] will be destroyed
# module.weka_deployment.random_password.password will be destroyed
# module.weka_deployment.google_storage_bucket_object.cloud_functions_zip must be replaced
# module.weka_deployment.google_secret_manager_secret_version.user_secret_key must be replaced

# module.weka_deployment.module.service_account[0].google_project_iam_member.sa_member_role["roles/secretmanager.secretVersionAdder"] will be created
# module.weka_deployment.google_storage_bucket_object.nfs_state[0] will be created
# module.weka_deployment.google_secret_manager_secret.weka_deployment_password will be created
# module.weka_deployment.google_compute_instance_group.nfs[0] will be created
```
- removed NFS VMs from state:
```
terraform state rm "module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_from_template.this"
Removed module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_from_template.this[0]
Removed module.weka_deployment.module.nfs_protocol_gateways[0].google_compute_instance_from_template.this[1]
Successfully removed 2 resource instance(s).
```
- after removal - tf apply replaced nfs template
- nfs state before scale_up
```
curl -m 70 -X POST "https://kr-kristina-status-v5lrsk3bvq-ew.a.run.app" \
  -H "Authorization:bearer $(gcloud auth print-identity-token)" \
  -H "Content-Type:application/json" -d '{"type":"progress", "protocol":"nfs"}' | jq
{
  "ready_for_clusterization": null,
  "progress": null,
  "errors": null,
  "debug": null,
  "in_progress": null,
  "summary": {
    "ready_for_clusterization": 0,
    "stopped": 0,
    "in_progress": 0,
    "unknown": null,
    "clusterization_target": 2,
    "clusterization_instance": "",
    "clusterized": false
  }
}
```
- disabled triggers and manually ran scale_up
```
curl -m 70 -X POST "https://kr-kristina-weka-functions-v5lrsk3bvq-ew.a.run.app?action=scale_up" \
  -H "Authorization:bearer $(gcloud auth print-identity-token)" \
  -H "Content-Type:application/json"
Migrating existing NFS instances completed successfully: [kr-kristina-nfs-protocol-gateway-instance-0 kr-kristina-nfs-protocol-gateway-instance-1]. Nothing to do%    
```
- nfs state after scale_up
```
curl -m 70 -X POST "https://kr-kristina-status-v5lrsk3bvq-ew.a.run.app" \
  -H "Authorization:bearer $(gcloud auth print-identity-token)" \
  -H "Content-Type:application/json" -d '{"type":"progress", "protocol":"nfs"}' | jq
{
  "ready_for_clusterization": null,
  "progress": {
    "kr-kristina-nfs-protocol-gateway-instance-0": [
      "16:02:53 UTC: Deletion protection was set successfully"
    ],
    "kr-kristina-nfs-protocol-gateway-instance-1": [
      "16:02:54 UTC: Deletion protection was set successfully"
    ]
  },
  "errors": null,
  "debug": null,
  "in_progress": null,
  "summary": {
    "ready_for_clusterization": 0,
    "stopped": 0,
    "in_progress": 0,
    "unknown": null,
    "clusterization_target": 2,
    "clusterization_instance": "",
    "clusterized": true
  }
}
```
NFS instances now have labels, are added to instance group and have deletion protection
