### PR TITLE
fix: allow empty clusterization_target for getting progress

### DIFF
--- a/cloud-functions/functions/status/status.go
+++ b/cloud-functions/functions/status/status.go
@@ -25,7 +25,7 @@ func GetReports(ctx context.Context, project, zone, bucket, object, instanceGrou
 	reports.Errors = state.Errors
 
 	clusterizationInstance := ""
-	if len(state.Instances) >= state.ClusterizationTarget {
+	if len(state.Instances) >= state.ClusterizationTarget && state.ClusterizationTarget > 0 {
 		clusterizationInstance = state.Instances[state.ClusterizationTarget-1].Name
 	}
 

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -31,7 +31,7 @@ data "archive_file" "function_zip" {
 
 # ================== function zip =======================
 resource "google_storage_bucket_object" "cloud_functions_zip" {
-  name       = "${var.prefix}-${var.cluster_name}-cloud-functions.zip"
+  name       = "${var.prefix}-${var.cluster_name}-cloud-functions-${filemd5(local.function_zip_path)}.zip"
   bucket     = local.state_bucket
   source     = local.function_zip_path
   depends_on = [data.archive_file.function_zip, google_project_service.run_api, google_project_service.artifactregistry_api]


### PR DESCRIPTION
- Fix upgrade from old TF module version (https://github.com/weka/terraform-gcp-weka/releases/tag/v4.0.8)
- Add workaround for GCP provider issue: https://github.com/hashicorp/terraform-provider-google/issues/17347