### PR TITLE
Allow using Cloud Run instead of Cloud Functions

### DIFF
--- a/clients.tf
+++ b/clients.tf
@@ -23,6 +23,7 @@ module "clients" {
   labels_map                   = var.labels_map
   depends_on = [
     google_compute_forwarding_rule.google_compute_forwarding_rule, google_workflows_workflow.scale_up,
-    google_cloudfunctions2_function.cloud_internal_function, module.shared_vpc_peering, module.peering
+    google_cloudfunctions2_function.cloud_internal_function, module.shared_vpc_peering, module.peering,
+    google_cloud_run_v2_service.cloud_internal
   ]
 }

--- a/cloud_functions.tf
+++ b/cloud_functions.tf
@@ -20,6 +20,92 @@ locals {
   user_email                             = data.google_client_openid_userinfo.user.email
   domain_name                            = split("@", local.user_email)[1]
   cloud_function_invoker_allowed_members = endswith(local.user_email, "gserviceaccount.com") ? concat(["serviceAccount:${local.user_email}", "serviceAccount:${local.sa_email}"]) : concat(["domain:${local.domain_name}", "serviceAccount:${local.sa_email}"])
+
+  cloud_internal_function_environment = {
+    PROJECT                = var.project_id
+    ZONE                   = var.zone
+    REGION                 = var.region
+    CLOUD_FUNCTION_NAME    = local.cloud_internal_function_name
+    INSTANCE_GROUP         = google_compute_instance_group.this.name
+    NFS_INSTANCE_GROUP     = var.nfs_setup_protocol ? google_compute_instance_group.nfs[0].name : ""
+    GATEWAYS               = join(",", [for s in data.google_compute_subnetwork.this : s.gateway_address])
+    SUBNETS                = format("(%s)", join(" ", [for s in data.google_compute_subnetwork.this : s.ip_cidr_range]))
+    USER_NAME_ID           = google_secret_manager_secret.secret_weka_username.id
+    ADMIN_PASSWORD_ID      = google_secret_manager_secret.secret_weka_password.id
+    DEPLOYMENT_PASSWORD_ID = google_secret_manager_secret.weka_deployment_password.id
+    TOKEN_ID               = var.get_weka_io_token == "" ? "" : google_secret_manager_secret.secret_token[0].id
+    BUCKET                 = local.state_bucket
+    STATE_OBJ_NAME         = local.state_object_name
+    INSTALL_URL            = local.install_weka_url
+    # Configuration for google_cloudfunctions2_function.cloud_internal_function may not refer to itself.
+    # REPORT_URL = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
+    NICS_NUM                     = local.nics_number
+    COMPUTE_MEMORY               = local.get_compute_memory
+    DRIVE_CONTAINER_CORES_NUM    = var.containers_config_map[var.machine_type].drive
+    COMPUTE_CONTAINER_CORES_NUM  = var.set_dedicated_fe_container ? var.containers_config_map[var.machine_type].compute : var.containers_config_map[var.machine_type].compute + 1
+    FRONTEND_CONTAINER_CORES_NUM = var.set_dedicated_fe_container ? var.containers_config_map[var.machine_type].frontend : 0
+    NVMES_NUM                    = var.nvmes_number
+    HOSTS_NUM                    = var.cluster_size
+    NICS_NUM                     = local.nics_number
+    CLUSTER_NAME                 = var.cluster_name
+    PREFIX                       = var.prefix
+    INSTALL_DPDK                 = var.install_cluster_dpdk
+    PROTECTION_LEVEL             = var.protection_level
+    STRIPE_WIDTH                 = var.stripe_width != -1 ? var.stripe_width : local.stripe_width
+    HOTSPARE                     = var.hotspare
+    SET_OBS                      = var.tiering_enable_obs_integration
+    OBS_NAME                     = var.tiering_obs_name == "" ? "" : var.tiering_obs_name
+    OBS_TIERING_SSD_PERCENT      = var.tiering_enable_ssd_percent
+    TIERING_TARGET_SSD_RETENTION = var.tiering_obs_target_ssd_retention
+    TIERING_START_DEMOTE         = var.tiering_obs_start_demote
+    DISK_NAME                    = var.default_disk_name
+    # for terminate
+    LOAD_BALANCER_NAME = google_compute_region_backend_service.backend_service.name
+    # for scale_up
+    YUM_REPO_SERVER  = var.yum_repo_server
+    BACKEND_TEMPLATE = google_compute_instance_template.this.id
+    # SMBW
+    CREATE_CONFIG_FS = (var.smbw_enabled && var.smb_setup_protocol) || var.s3_setup_protocol
+    # Weka proxy url
+    PROXY_URL                     = var.proxy_url
+    WEKA_HOME_URL                 = var.weka_home_url
+    DOWN_BACKENDS_REMOVAL_TIMEOUT = var.debug_down_backends_removal_timeout
+    BACKEND_LB_IP                 = google_compute_forwarding_rule.google_compute_forwarding_rule.ip_address
+    TRACES_PER_FRONTEND           = var.traces_per_ionode
+    # NFS vars
+    NFS_GATEWAYS_NAME                 = var.nfs_setup_protocol ? local.gateways_name : ""
+    NFS_STATE_OBJ_NAME                = var.nfs_setup_protocol ? local.nfs_state_object_name : ""
+    NFS_GATEWAYS_TEMPLATE_NAME        = var.nfs_setup_protocol ? local.gateways_name : ""
+    NFS_INTERFACE_GROUP_NAME          = var.nfs_interface_group_name
+    NFS_SECONDARY_IPS_NUM             = var.nfs_protocol_gateway_secondary_ips_per_nic
+    NFS_PROTOCOL_GATEWAY_FE_CORES_NUM = var.nfs_protocol_gateway_fe_cores_num
+    NFS_PROTOCOL_GATEWAYS_NUM         = var.nfs_protocol_gateways_number
+    NFS_DISK_SIZE                     = var.nfs_protocol_gateway_disk_size
+    SMB_DISK_SIZE                     = var.smb_protocol_gateway_disk_size
+    S3_DISK_SIZE                      = var.s3_protocol_gateway_disk_size
+    SMB_PROTOCOL_GATEWAY_FE_CORES_NUM = var.smb_protocol_gateway_fe_cores_num
+    S3_PROTOCOL_GATEWAY_FE_CORES_NUM  = var.s3_protocol_gateway_fe_cores_num
+    SET_DEFAULT_FS                    = var.set_default_fs
+    POST_CLUSTER_SETUP_SCRIPT         = var.post_cluster_setup_script
+  }
+
+  status_function_environment = {
+    PROJECT                = var.project_id
+    ZONE                   = var.zone
+    BUCKET                 = local.state_bucket
+    STATE_OBJ_NAME         = local.state_object_name
+    NFS_STATE_OBJ_NAME     = var.nfs_setup_protocol ? local.nfs_state_object_name : ""
+    INSTANCE_GROUP         = google_compute_instance_group.this.name
+    NFS_INSTANCE_GROUP     = var.nfs_setup_protocol ? google_compute_instance_group.nfs[0].name : ""
+    USER_NAME_ID           = google_secret_manager_secret.secret_weka_username.id
+    ADMIN_PASSWORD_ID      = google_secret_manager_secret.secret_weka_password.id
+    DEPLOYMENT_PASSWORD_ID = google_secret_manager_secret.weka_deployment_password.id
+  }
+  is_using_cloudfunctions = var.cloud_run_image_prefix == null
+  internal_function_uri   = local.is_using_cloudfunctions ? google_cloudfunctions2_function.cloud_internal_function[0].service_config[0].uri : google_cloud_run_v2_service.cloud_internal[0].uri
+  scaleup_function_uri    = local.is_using_cloudfunctions ? google_cloudfunctions2_function.scale_down_function[0].service_config[0].uri : google_cloud_run_v2_service.scale_down[0].uri
+  status_function_uri     = local.is_using_cloudfunctions ? google_cloudfunctions2_function.status_function[0].service_config[0].uri : google_cloud_run_v2_service.status[0].uri
+
 }
 
 data "archive_file" "function_zip" {
@@ -40,6 +126,7 @@ resource "google_storage_bucket_object" "cloud_functions_zip" {
 
 # ======================== deploy ============================
 resource "google_cloudfunctions2_function" "cloud_internal_function" {
+  count       = local.is_using_cloudfunctions ? 1 : 0
   name        = local.cloud_internal_function_name
   description = "deploy, fetch, resize, clusterize, clusterize finalization, join, join_finalization, join_nfs_finalization, terminate, transient, terminate_cluster, scale_up functions"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
@@ -64,73 +151,7 @@ resource "google_cloudfunctions2_function" "cloud_internal_function" {
     vpc_connector_egress_settings  = var.vpc_connector_egress_settings
     all_traffic_on_latest_revision = true
     service_account_email          = local.sa_email
-    environment_variables = {
-      PROJECT : var.project_id
-      ZONE : var.zone
-      REGION : var.region
-      CLOUD_FUNCTION_NAME : local.cloud_internal_function_name
-      INSTANCE_GROUP : google_compute_instance_group.this.name
-      NFS_INSTANCE_GROUP : var.nfs_setup_protocol ? google_compute_instance_group.nfs[0].name : ""
-      GATEWAYS : join(",", [for s in data.google_compute_subnetwork.this : s.gateway_address])
-      SUBNETS : format("(%s)", join(" ", [for s in data.google_compute_subnetwork.this : s.ip_cidr_range]))
-      USER_NAME_ID : google_secret_manager_secret.secret_weka_username.id
-      ADMIN_PASSWORD_ID = google_secret_manager_secret.secret_weka_password.id
-      DEPLOYMENT_PASSWORD_ID : google_secret_manager_secret.weka_deployment_password.id
-      TOKEN_ID : var.get_weka_io_token == "" ? "" : google_secret_manager_secret.secret_token[0].id
-      BUCKET : local.state_bucket
-      STATE_OBJ_NAME : local.state_object_name
-      INSTALL_URL : local.install_weka_url
-      # Configuration for google_cloudfunctions2_function.cloud_internal_function may not refer to itself.
-      # REPORT_URL : format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
-      NICS_NUM : local.nics_number
-      COMPUTE_MEMORY : local.get_compute_memory
-      DRIVE_CONTAINER_CORES_NUM : var.containers_config_map[var.machine_type].drive
-      COMPUTE_CONTAINER_CORES_NUM : var.set_dedicated_fe_container ? var.containers_config_map[var.machine_type].compute : var.containers_config_map[var.machine_type].compute + 1
-      FRONTEND_CONTAINER_CORES_NUM : var.set_dedicated_fe_container ? var.containers_config_map[var.machine_type].frontend : 0
-      NVMES_NUM : var.nvmes_number
-      HOSTS_NUM : var.cluster_size
-      NICS_NUM : local.nics_number
-      CLUSTER_NAME : var.cluster_name
-      PREFIX : var.prefix
-      INSTALL_DPDK : var.install_cluster_dpdk
-      PROTECTION_LEVEL : var.protection_level
-      STRIPE_WIDTH : var.stripe_width != -1 ? var.stripe_width : local.stripe_width
-      HOTSPARE : var.hotspare
-      SET_OBS : var.tiering_enable_obs_integration
-      OBS_NAME : var.tiering_obs_name == "" ? "" : var.tiering_obs_name
-      OBS_TIERING_SSD_PERCENT : var.tiering_enable_ssd_percent
-      TIERING_TARGET_SSD_RETENTION : var.tiering_obs_target_ssd_retention
-      TIERING_START_DEMOTE : var.tiering_obs_start_demote
-      DISK_NAME : var.default_disk_name
-      # for terminate
-      LOAD_BALANCER_NAME : google_compute_region_backend_service.backend_service.name
-      # for scale_up
-      YUM_REPO_SERVER : var.yum_repo_server
-      BACKEND_TEMPLATE : google_compute_instance_template.this.id
-      # SMBW
-      CREATE_CONFIG_FS : (var.smbw_enabled && var.smb_setup_protocol) || var.s3_setup_protocol
-      # Weka proxy url
-      PROXY_URL : var.proxy_url
-      WEKA_HOME_URL : var.weka_home_url
-      DOWN_BACKENDS_REMOVAL_TIMEOUT : var.debug_down_backends_removal_timeout
-      BACKEND_LB_IP : google_compute_forwarding_rule.google_compute_forwarding_rule.ip_address
-      TRACES_PER_FRONTEND : var.traces_per_ionode
-      # NFS vars
-      NFS_GATEWAYS_NAME : var.nfs_setup_protocol ? local.gateways_name : ""
-      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? local.nfs_state_object_name : ""
-      NFS_GATEWAYS_TEMPLATE_NAME : var.nfs_setup_protocol ? local.gateways_name : ""
-      NFS_INTERFACE_GROUP_NAME : var.nfs_interface_group_name
-      NFS_SECONDARY_IPS_NUM : var.nfs_protocol_gateway_secondary_ips_per_nic
-      NFS_PROTOCOL_GATEWAY_FE_CORES_NUM : var.nfs_protocol_gateway_fe_cores_num
-      NFS_PROTOCOL_GATEWAYS_NUM : var.nfs_protocol_gateways_number
-      NFS_DISK_SIZE : var.nfs_protocol_gateway_disk_size
-      SMB_DISK_SIZE                     = var.smb_protocol_gateway_disk_size
-      S3_DISK_SIZE                      = var.s3_protocol_gateway_disk_size
-      SMB_PROTOCOL_GATEWAY_FE_CORES_NUM = var.smb_protocol_gateway_fe_cores_num
-      S3_PROTOCOL_GATEWAY_FE_CORES_NUM  = var.s3_protocol_gateway_fe_cores_num
-      SET_DEFAULT_FS                    = var.set_default_fs
-      POST_CLUSTER_SETUP_SCRIPT         = var.post_cluster_setup_script
-    }
+    environment_variables          = local.cloud_internal_function_environment
   }
   labels = merge(var.labels_map, {
     goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
@@ -146,15 +167,18 @@ resource "google_cloudfunctions2_function" "cloud_internal_function" {
 
 # IAM entry for all users to invoke the function
 resource "google_cloudfunctions2_function_iam_member" "cloud_internal_invoker" {
-  count          = length(local.cloud_function_invoker_allowed_members)
-  location       = google_cloudfunctions2_function.cloud_internal_function.location
-  cloud_function = google_cloudfunctions2_function.cloud_internal_function.name
+  count          = local.is_using_cloudfunctions ? length(local.cloud_function_invoker_allowed_members) : 0
+  location       = google_cloudfunctions2_function.cloud_internal_function[0].location
+  cloud_function = google_cloudfunctions2_function.cloud_internal_function[0].name
   role           = "roles/cloudfunctions.invoker"
   member         = local.cloud_function_invoker_allowed_members[count.index]
 }
 
+
+
 # ======================== scale_down ============================
 resource "google_cloudfunctions2_function" "scale_down_function" {
+  count       = local.is_using_cloudfunctions ? 1 : 0
   name        = "${var.prefix}-${var.cluster_name}-scale-down"
   description = "scale cluster down"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
@@ -188,15 +212,16 @@ resource "google_cloudfunctions2_function" "scale_down_function" {
 
 # IAM entry for all users to invoke the function
 resource "google_cloudfunctions2_function_iam_member" "weka_internal_invoker" {
-  count          = length(local.cloud_function_invoker_allowed_members)
-  location       = google_cloudfunctions2_function.cloud_internal_function.location
-  cloud_function = google_cloudfunctions2_function.cloud_internal_function.name
+  count          = local.is_using_cloudfunctions ? length(local.cloud_function_invoker_allowed_members) : 0
+  location       = google_cloudfunctions2_function.cloud_internal_function[0].location
+  cloud_function = google_cloudfunctions2_function.cloud_internal_function[0].name
   role           = "roles/cloudfunctions.invoker"
   member         = local.cloud_function_invoker_allowed_members[count.index]
 }
 
 # ======================== status ============================
 resource "google_cloudfunctions2_function" "status_function" {
+  count       = local.is_using_cloudfunctions ? 1 : 0
   name        = "${var.prefix}-${var.cluster_name}-status"
   description = "get cluster status"
   location    = lookup(var.cloud_functions_region_map, var.region, var.region)
@@ -222,18 +247,7 @@ resource "google_cloudfunctions2_function" "status_function" {
     vpc_connector_egress_settings  = var.vpc_connector_egress_settings
     all_traffic_on_latest_revision = true
     service_account_email          = local.sa_email
-    environment_variables = {
-      PROJECT : var.project_id
-      ZONE : var.zone
-      BUCKET : local.state_bucket
-      STATE_OBJ_NAME : local.state_object_name
-      NFS_STATE_OBJ_NAME : var.nfs_setup_protocol ? local.nfs_state_object_name : ""
-      INSTANCE_GROUP : google_compute_instance_group.this.name
-      NFS_INSTANCE_GROUP : var.nfs_setup_protocol ? google_compute_instance_group.nfs[0].name : ""
-      USER_NAME_ID : google_secret_manager_secret.secret_weka_username.id
-      ADMIN_PASSWORD_ID : google_secret_manager_secret.secret_weka_password.id
-      DEPLOYMENT_PASSWORD_ID : google_secret_manager_secret.weka_deployment_password.id
-    }
+    environment_variables          = local.status_function_environment
   }
   labels = merge(var.labels_map, {
     goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
@@ -243,9 +257,9 @@ resource "google_cloudfunctions2_function" "status_function" {
 
 # IAM entry for all users to invoke the function
 resource "google_cloudfunctions2_function_iam_member" "status_invoker" {
-  count          = length(local.cloud_function_invoker_allowed_members)
-  location       = google_cloudfunctions2_function.status_function.location
-  cloud_function = google_cloudfunctions2_function.status_function.name
+  count          = local.is_using_cloudfunctions ? length(local.cloud_function_invoker_allowed_members) : 0
+  location       = google_cloudfunctions2_function.status_function[0].location
+  cloud_function = google_cloudfunctions2_function.status_function[0].name
   role           = "roles/cloudfunctions.invoker"
   member         = local.cloud_function_invoker_allowed_members[count.index]
 }

--- a/cloudrun.tf
+++ b/cloudrun.tf
@@ -1,0 +1,169 @@
+locals {
+  cloudrun_ingress_map = {
+    ALLOW_ALL               = "INGRESS_TRAFFIC_ALL"
+    ALLOW_INTERNAL_ONLY     = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+    ALLOW_INTERNAL_AND_GCLB = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  }
+}
+# ======================== deploy ============================
+resource "google_cloud_run_v2_service" "cloud_internal" {
+  count       = local.is_using_cloudfunctions ? 0 : 1
+  name        = local.cloud_internal_function_name
+  description = "deploy, fetch, resize, clusterize, clusterize finalization, join, join_finalization, terminate, transient, terminate_cluster, scale_up functions"
+  location    = lookup(var.cloud_functions_region_map, var.region, var.region)
+  ingress     = local.cloudrun_ingress_map[local.function_ingress_settings]
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  template {
+    timeout = "540s"
+    scaling {
+      max_instance_count = 20
+      min_instance_count = 1
+    }
+    service_account = local.sa_email
+    vpc_access {
+      connector = local.vpc_connector_id
+      egress    = "ALL_TRAFFIC"
+    }
+    containers {
+      image = "${var.cloud_run_image_prefix}-cloudinternal"
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.cloud_internal_function_environment
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+  }
+  labels = {
+    goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
+  }
+  depends_on = [module.network, module.worker_pool, module.shared_vpc_peering, module.peering, google_project_service.run_api]
+}
+
+# IAM entry for all users to invoke the function
+resource "google_cloud_run_v2_service_iam_member" "cloud_internal_invoker" {
+  # can't use for_each here, as the elements of `cloud_function_invoker_allowed_members` are known after apply on first run
+  count    = local.is_using_cloudfunctions ? 0 : length(local.cloud_function_invoker_allowed_members)
+  location = google_cloud_run_v2_service.cloud_internal[0].location
+  name     = google_cloud_run_v2_service.cloud_internal[0].name
+  role     = "roles/run.invoker"
+  member   = local.cloud_function_invoker_allowed_members[count.index]
+}
+
+# ======================== scale_down ============================
+resource "google_cloud_run_v2_service" "scale_down" {
+  count       = local.is_using_cloudfunctions ? 0 : 1
+  name        = "${var.prefix}-${var.cluster_name}-scale-down"
+  description = "scale cluster down"
+  location    = lookup(var.cloud_functions_region_map, var.region, var.region)
+  ingress     = local.cloudrun_ingress_map[local.function_ingress_settings]
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  template {
+    timeout = "540s"
+    scaling {
+      max_instance_count = 3
+      min_instance_count = 1
+    }
+    service_account = local.sa_email
+    vpc_access {
+      connector = local.vpc_connector_id
+      egress    = "ALL_TRAFFIC"
+    }
+    containers {
+      image = "${var.cloud_run_image_prefix}-scaledown"
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+    }
+  }
+  labels = {
+    goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
+  }
+  depends_on = [module.network, module.worker_pool, module.shared_vpc_peering, google_project_service.run_api]
+}
+
+# IAM entry for all users to invoke the function
+resource "google_cloud_run_v2_service_iam_member" "weka_internal_invoker" {
+  # can't use for_each here, as the elements of `cloud_function_invoker_allowed_members` are known after apply on first run
+  count    = local.is_using_cloudfunctions ? 0 : length(local.cloud_function_invoker_allowed_members)
+  location = google_cloud_run_v2_service.scale_down[0].location
+  name     = google_cloud_run_v2_service.scale_down[0].name
+  role     = "roles/run.invoker"
+  member   = local.cloud_function_invoker_allowed_members[count.index]
+}
+
+
+# ======================== status ============================
+resource "google_cloud_run_v2_service" "status" {
+  count       = local.is_using_cloudfunctions ? 0 : 1
+  name        = "${var.prefix}-${var.cluster_name}-status"
+  description = "get cluster status"
+  location    = lookup(var.cloud_functions_region_map, var.region, var.region)
+  ingress     = local.cloudrun_ingress_map[local.function_ingress_settings]
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  template {
+    timeout = "540s"
+    scaling {
+      max_instance_count = 3
+      min_instance_count = 1
+    }
+    service_account = local.sa_email
+    vpc_access {
+      connector = local.vpc_connector_id
+      egress    = "ALL_TRAFFIC"
+    }
+    containers {
+      image = "${var.cloud_run_image_prefix}-status"
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+      dynamic "env" {
+        for_each = local.status_function_environment
+        content {
+          name  = env.key
+          value = env.value
+        }
+
+      }
+    }
+  }
+  labels = {
+    goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
+  }
+  depends_on = [module.network, module.worker_pool, module.shared_vpc_peering, google_project_service.run_api]
+}
+
+# IAM entry for all users to invoke the function
+resource "google_cloud_run_v2_service_iam_member" "status_invoker" {
+  count    = local.is_using_cloudfunctions ? 0 : length(local.cloud_function_invoker_allowed_members)
+  location = google_cloud_run_v2_service.status[0].location
+  name     = google_cloud_run_v2_service.status[0].name
+  role     = "roles/run.invoker"
+  member   = local.cloud_function_invoker_allowed_members[count.index]
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -3,6 +3,11 @@ output "vpcs_names" {
   description = "List of vpcs names"
 }
 
+output "vpc_self_links" {
+  value       = [for v in google_compute_network.vpc_network : v.self_link]
+  description = "List of VPC self-links"
+}
+
 output "gateway_address" {
   value       = length(var.subnets) == 0 ? length(var.subnets_range) > 0 ? [for g in google_compute_subnetwork.subnetwork : g.gateway_address] : [] : [for g in data.google_compute_subnetwork.subnets_list_ids : g.gateway_address]
   description = "List of vpcs gateway addresses"

--- a/protocol_gateways.tf
+++ b/protocol_gateways.tf
@@ -1,6 +1,6 @@
 resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
-  depends_on      = [google_cloudfunctions2_function.cloud_internal_function]
+  depends_on      = [google_cloudfunctions2_function.cloud_internal_function, google_cloud_run_v2_service.cloud_internal]
 }
 
 module "nfs_protocol_gateways" {
@@ -27,10 +27,10 @@ module "nfs_protocol_gateways" {
   vm_username                  = var.vm_username
   ssh_public_key               = local.ssh_public_key
   traces_per_frontend          = var.traces_per_ionode
-  deploy_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=deploy")
-  report_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
+  deploy_function_url          = format("%s%s", local.internal_function_uri, "?action=deploy")
+  report_function_url          = format("%s%s", local.internal_function_uri, "?action=report")
   labels_map                   = var.labels_map
-  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function]
+  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function, google_cloud_run_v2_service.cloud_internal]
 }
 
 
@@ -61,10 +61,10 @@ module "smb_protocol_gateways" {
   vm_username                  = var.vm_username
   ssh_public_key               = local.ssh_public_key
   traces_per_frontend          = var.traces_per_ionode
-  deploy_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=deploy")
-  report_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
+  deploy_function_url          = format("%s%s", local.internal_function_uri, "?action=deploy")
+  report_function_url          = format("%s%s", local.internal_function_uri, "?action=report")
   labels_map                   = var.labels_map
-  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function]
+  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function, google_cloud_run_v2_service.cloud_internal]
 }
 
 
@@ -92,8 +92,8 @@ module "s3_protocol_gateways" {
   vm_username                  = var.vm_username
   ssh_public_key               = local.ssh_public_key
   traces_per_frontend          = var.traces_per_ionode
-  deploy_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=deploy")
-  report_function_url          = format("%s%s", google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri, "?action=report")
+  deploy_function_url          = format("%s%s", local.internal_function_uri, "?action=deploy")
+  report_function_url          = format("%s%s", local.internal_function_uri, "?action=report")
   labels_map                   = var.labels_map
-  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function]
+  depends_on                   = [module.network, module.peering, module.shared_vpc_peering, time_sleep.wait_120_seconds, google_compute_forwarding_rule.google_compute_forwarding_rule, google_secret_manager_secret.secret_token, google_cloudfunctions2_function.cloud_internal_function, google_cloud_run_v2_service.cloud_internal]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -241,6 +241,12 @@ variable "cloud_functions_region_map" {
   }
 }
 
+variable "cloud_run_image_prefix" {
+  type        = string
+  description = "Image reference for Cloud Functions"
+  default     = null
+}
+
 variable "workflow_map_region" {
   type        = map(string)
   description = "Defines a mapping between regions lacking Cloud Workflows functionality and alternative regions. It ensures Cloud Workflows functionality by redirecting workflows to supported regions when necessary."

--- a/workflows.tf
+++ b/workflows.tf
@@ -23,7 +23,7 @@ resource "google_workflows_workflow" "scale_down" {
   - fetch:
       call: http.post
       args:
-          url: ${google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri}
+          url: ${local.internal_function_uri}
           query:
             action: fetch
           auth:
@@ -32,7 +32,7 @@ resource "google_workflows_workflow" "scale_down" {
   - scale_down:
       call: http.post
       args:
-          url: ${google_cloudfunctions2_function.scale_down_function.service_config[0].uri}
+          url: ${local.scaleup_function_uri}
           body: $${FetchResult.body}
           auth:
             type: OIDC
@@ -40,7 +40,7 @@ resource "google_workflows_workflow" "scale_down" {
   - terminate:
       call: http.post
       args:
-          url: ${google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri}
+          url: ${local.internal_function_uri}
           query:
             action: terminate
           body: $${ScaleResult.body}
@@ -50,7 +50,7 @@ resource "google_workflows_workflow" "scale_down" {
   - transient:
       call: http.post
       args:
-          url: ${google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri}
+          url: ${local.internal_function_uri}
           query:
             action: transient
           body: $${TerminateResult.body}
@@ -63,7 +63,11 @@ EOF
   labels = merge(var.labels_map, {
     goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
   })
-  depends_on = [google_project_service.workflows, google_cloudfunctions2_function.scale_down_function, google_cloudfunctions2_function.cloud_internal_function]
+  depends_on = [
+    google_project_service.workflows,
+    google_cloudfunctions2_function.scale_down_function, google_cloudfunctions2_function.cloud_internal_function,
+    google_cloud_run_v2_service.scale_down, google_cloud_run_v2_service.cloud_internal
+  ]
 }
 
 resource "google_pubsub_topic" "scale_down_trigger_topic" {
@@ -127,7 +131,7 @@ resource "google_workflows_workflow" "scale_up" {
   - scale_up:
       call: http.get
       args:
-          url: ${google_cloudfunctions2_function.cloud_internal_function.service_config[0].uri}
+          url: ${local.internal_function_uri}
           query:
             action: scale_up
           auth:
@@ -139,7 +143,7 @@ EOF
   labels = merge(var.labels_map, {
     goog-partner-solution = "isol_plb32_0014m00001h34hnqai_by7vmugtismizv6y46toim6jigajtrwh"
   })
-  depends_on = [google_project_service.workflows, google_cloudfunctions2_function.cloud_internal_function]
+  depends_on = [google_project_service.workflows, google_cloudfunctions2_function.cloud_internal_function, google_cloud_run_v2_service.cloud_internal]
 }
 
 resource "google_pubsub_topic" "scale_up_trigger_topic" {


### PR DESCRIPTION
For customers that are not able to use Cloud Build to build functions provide the possibility to use Cloud Run with pre-built containers.

Containers are specified providing `cloud_function_image_prefix`, for example for value `us-central1-docker.pkg.dev/${local.project_id}/${local.repository_name}/weka-functions-container`, following containers are expected in `local.repository_name` in `local.project_id` project:
* weka-functions-container-cloudinternal
* weka-functions-container-scale-down
* weka-functions-container-status

Containers can be build using [pack](https://buildpacks.io/docs/tools/pack/):
```shell
for ENTRY_POINT in CloudInternal ScaleDown Status ; do
    pack build --builder=gcr.io/buildpacks/builder \
        --env GOOGLE_FUNCTION_TARGET=${ENTRY_POINT} \
        us-central1-docker.pkg.dev/${GCP_PROJECT_ID}/${REPOSITORY}/weka-functions-container-$(echo ${ENTRY_POINT} |\
        tr '[:upper:]' '[:lower:]')
done
```

Ideally, containers could be provided in WEKA managed repository, but customer should be able to point to their own repository and use customer's process to stage containers from external repository into internal ones.
